### PR TITLE
Update Shiden website address

### DIFF
--- a/crowdloan/kusama.json
+++ b/crowdloan/kusama.json
@@ -14,7 +14,7 @@
     "name": "Shiden",
     "token": "SDN",
     "description": "Shiden Network is a multi-chain decentralized application layer on Kusama",
-    "website": "https://shiden.plasmnet.io/",
+    "website": "https://shiden.astar.network",
     "icon": "https://raw.githubusercontent.com/soramitsu/fearless-utils/master/crowdloan/icons/shiden.svg",
     "rewardRate": 25
   },


### PR DESCRIPTION
Update Shiden website address as the old one phased out due to the rebranding