### PR TITLE
add option to override types per chain

### DIFF
--- a/chains/chains.json
+++ b/chains/chains.json
@@ -18,7 +18,10 @@
     ],
     "icon": "https://raw.githubusercontent.com/soramitsu/fearless-utils/master/chains/icons/polkadot.svg",
     "addressPrefix": 0,
-    "types": "https://raw.githubusercontent.com/polkascan/py-scale-codec/master/scalecodec/type_registry/polkadot.json",
+    "types": {
+      "url": "https://raw.githubusercontent.com/polkascan/py-scale-codec/master/scalecodec/type_registry/polkadot.json",
+      "overridesCommon": false
+    },
     "isEthereumBased": false
   },
   {
@@ -39,7 +42,10 @@
     ],
     "icon": "https://raw.githubusercontent.com/soramitsu/fearless-utils/master/chains/icons/kusama.svg",
     "addressPrefix": 2,
-    "types": "https://raw.githubusercontent.com/polkascan/py-scale-codec/master/scalecodec/type_registry/kusama.json",
+    "types": {
+      "url": "https://raw.githubusercontent.com/polkascan/py-scale-codec/master/scalecodec/type_registry/kusama.json",
+      "overridesCommon": false
+    },
     "isEthereumBased": false
   }
 ]


### PR DESCRIPTION
Turn `types` field to optional object with the following semantics:

- if missing then chain uses common types
- If set then types for chain must be downloaded by url and `ovveridesCommon` flag says whether this type should be used instead of common or just represent additional types (and versioning for them).